### PR TITLE
Changed the fixtures for trial permissions to include a record for user1

### DIFF
--- a/tests/fixtures/user_trial_permission.php
+++ b/tests/fixtures/user_trial_permission.php
@@ -1,13 +1,20 @@
 <?php
 
 return array(
+
     'user_trial_permission_1' => array(
+        'user_id' => $this->getRecord('user', 'user1')->id,
+        'trial_id' => $this->getRecord('trial', 'trial1')->id,
+        'permission' => UserTrialPermission::PERMISSION_MANAGE,
+    ),
+
+    'user_trial_permission_2' => array(
         'user_id' => $this->getRecord('user', 'user2')->id,
         'trial_id' => $this->getRecord('trial', 'trial1')->id,
         'permission' => UserTrialPermission::PERMISSION_VIEW,
     ),
 
-    'user_trial_permission_2' => array(
+    'user_trial_permission_3' => array(
         'user_id' => $this->getRecord('user', 'user3')->id,
         'trial_id' => $this->getRecord('trial', 'trial1')->id,
         'permission' => UserTrialPermission::PERMISSION_EDIT,

--- a/tests/unit/models/TrialTest.php
+++ b/tests/unit/models/TrialTest.php
@@ -75,7 +75,7 @@ class TrialTest extends CDbTestCase
         $this->assertFalse($this->trial('trial2')->hasShortlistedPatients());
     }
 
-    public function testCheckTrialAccessForOwner()
+    public function testCheckTrialAccessManage()
     {
         $this->assertTrue(Trial::checkTrialAccess($this->user('user1'), $this->trial('trial1')->id,
             UserTrialPermission::PERMISSION_VIEW), 'user1 should have view access to trial1');


### PR DESCRIPTION
Changed the fixtures for trial permissions to include a record for user1 (the permission used to be implicit from user1 owning the trial)